### PR TITLE
Profiles onboarding

### DIFF
--- a/VolunQueer/VolunQueer/Data/AppStore.swift
+++ b/VolunQueer/VolunQueer/Data/AppStore.swift
@@ -88,9 +88,38 @@ final class AppStore: ObservableObject {
         organizations.first { $0.id == event.orgId }
     }
 
+    /// User profile for the given ID.
+    func user(for id: String) -> AppUser? {
+        users.first { $0.id == id }
+    }
+
     /// Roles for an event (from mock bundle; Firestore subcollection can be wired later).
     func roles(for event: Event) -> [EventRole] {
         rolesByEvent[event.id] ?? []
+    }
+
+    /// Saves a user profile and updates local state.
+    func saveUser(_ user: AppUser) async throws {
+        if dataSource == .firestore, let firestore {
+            try await firestore.setDocument("users", id: user.id, value: user)
+        }
+        if let index = users.firstIndex(where: { $0.id == user.id }) {
+            users[index] = user
+        } else {
+            users.append(user)
+        }
+    }
+
+    /// Saves an organization and updates local state.
+    func saveOrganization(_ organization: Organization) async throws {
+        if dataSource == .firestore, let firestore {
+            try await firestore.setDocument("organizations", id: organization.id, value: organization)
+        }
+        if let index = organizations.firstIndex(where: { $0.id == organization.id }) {
+            organizations[index] = organization
+        } else {
+            organizations.append(organization)
+        }
     }
 
     /// Published events suitable for discovery.

--- a/VolunQueer/VolunQueer/Models/Weekday.swift
+++ b/VolunQueer/VolunQueer/Models/Weekday.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Days of the week.
-enum Weekday: String, Codable, Hashable {
+enum Weekday: String, Codable, Hashable, CaseIterable {
     case monday
     case tuesday
     case wednesday

--- a/VolunQueer/VolunQueer/Services/MockRSVPService.swift
+++ b/VolunQueer/VolunQueer/Services/MockRSVPService.swift
@@ -40,7 +40,7 @@ actor MockRSVPService: RSVPService {
     }
 
     func fetchRsvps(eventId: String) async throws -> [RSVP] {
-        let rsvps = rsvpsByEvent[eventId]?.values ?? []
+        let rsvps = rsvpsByEvent[eventId].map { Array($0.values) } ?? []
         return rsvps.map { rsvp in
             if rsvp.eventId == nil {
                 var updated = rsvp

--- a/VolunQueer/VolunQueer/ViewModels/OnboardingAvailabilityPeriod.swift
+++ b/VolunQueer/VolunQueer/ViewModels/OnboardingAvailabilityPeriod.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Simple availability blocks used during onboarding.
+enum OnboardingAvailabilityPeriod: String, CaseIterable, Identifiable {
+    case morning
+    case afternoon
+    case evening
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .morning:
+            return "Morning"
+        case .afternoon:
+            return "Afternoon"
+        case .evening:
+            return "Evening"
+        }
+    }
+
+    var window: TimeWindow {
+        switch self {
+        case .morning:
+            return TimeWindow(startMinutes: 9 * 60, endMinutes: 12 * 60)
+        case .afternoon:
+            return TimeWindow(startMinutes: 12 * 60, endMinutes: 17 * 60)
+        case .evening:
+            return TimeWindow(startMinutes: 17 * 60, endMinutes: 21 * 60)
+        }
+    }
+}

--- a/VolunQueer/VolunQueer/ViewModels/OnboardingStatus.swift
+++ b/VolunQueer/VolunQueer/ViewModels/OnboardingStatus.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Computes whether a user needs onboarding.
+enum OnboardingStatus {
+    static func requiresOnboarding(for user: AppUser?) -> Bool {
+        guard let user else { return true }
+        if user.roles.isEmpty { return true }
+        if user.contact?.email?.isEmpty != false { return true }
+        if user.roles.contains(.volunteer), user.volunteerProfile == nil {
+            return true
+        }
+        if user.roles.contains(.organizer), user.organizerProfile == nil {
+            return true
+        }
+        return false
+    }
+}

--- a/VolunQueer/VolunQueer/ViewModels/OnboardingStep.swift
+++ b/VolunQueer/VolunQueer/ViewModels/OnboardingStep.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Steps shown during onboarding.
+enum OnboardingStep: String, CaseIterable, Identifiable {
+    case role
+    case basics
+    case volunteer
+    case organizer
+    case done
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .role:
+            return "Choose your path"
+        case .basics:
+            return "Basics & consent"
+        case .volunteer:
+            return "Volunteer profile"
+        case .organizer:
+            return "Organizer profile"
+        case .done:
+            return "You're all set"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .role:
+            return "Pick what you want to do right now. You can add more later."
+        case .basics:
+            return "Share only what organizers need to coordinate."
+        case .volunteer:
+            return "Tell us what you enjoy and when you’re free."
+        case .organizer:
+            return "Set up the organization you’ll post events for."
+        case .done:
+            return "Your profile is ready."
+        }
+    }
+}

--- a/VolunQueer/VolunQueer/ViewModels/OnboardingViewModel.swift
+++ b/VolunQueer/VolunQueer/ViewModels/OnboardingViewModel.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Combine
+
+/// Holds onboarding state and builds profile models.
+@MainActor
+final class OnboardingViewModel: ObservableObject {
+    @Published var currentStepIndex: Int = 0
+    @Published var selectedRoles: Set<UserRole> = [.volunteer]
+
+    @Published var displayName: String = ""
+    @Published var pronouns: String = ""
+    @Published var email: String = ""
+    @Published var phone: String = ""
+    @Published var preferredChannel: ContactChannel = .email
+
+    @Published var shareEmail: Bool = true
+    @Published var sharePhone: Bool = false
+    @Published var sharePronouns: Bool = true
+    @Published var shareAccessibility: Bool = true
+
+    @Published var volunteerInterests: Set<String> = []
+    @Published var volunteerSkills: Set<String> = []
+    @Published var volunteerWeekdays: Set<Weekday> = []
+    @Published var volunteerPeriod: OnboardingAvailabilityPeriod = .evening
+    @Published var accessibilityNeeds: String = ""
+
+    @Published var organizationName: String = ""
+    @Published var organizerRoleTitle: String = ""
+    @Published var organizationMission: String = ""
+    @Published var organizationWebsite: String = ""
+
+    @Published private(set) var errorMessage: String?
+    @Published var isSaving: Bool = false
+    private var hasPrefilled = false
+
+    var steps: [OnboardingStep] {
+        var list: [OnboardingStep] = [.role, .basics]
+        if selectedRoles.contains(.volunteer) {
+            list.append(.volunteer)
+        }
+        if selectedRoles.contains(.organizer) {
+            list.append(.organizer)
+        }
+        list.append(.done)
+        return list
+    }
+
+    var currentStep: OnboardingStep {
+        steps[min(currentStepIndex, steps.count - 1)]
+    }
+
+    var progressValue: Double {
+        Double(currentStepIndex + 1) / Double(steps.count)
+    }
+
+    func advance() {
+        guard currentStepIndex + 1 < steps.count else { return }
+        currentStepIndex += 1
+    }
+
+    func back() {
+        guard currentStepIndex > 0 else { return }
+        currentStepIndex -= 1
+    }
+
+    func canAdvance() -> Bool {
+        switch currentStep {
+        case .role:
+            return !selectedRoles.isEmpty
+        case .basics:
+            guard !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+            guard !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+            if preferredChannel == .sms {
+                return !phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            return true
+        case .volunteer:
+            return true
+        case .organizer:
+            return !organizationName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .done:
+            return true
+        }
+    }
+
+    func buildUser(userId: String, orgId: String?) -> AppUser {
+        let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPronouns = pronouns.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let visibility = UserVisibility(
+            shareEmail: shareEmail,
+            sharePhone: sharePhone,
+            sharePronouns: sharePronouns,
+            shareAccessibility: shareAccessibility
+        )
+
+        let contact = ContactInfo(
+            email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+            phone: phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : phone,
+            preferredChannel: preferredChannel
+        )
+
+        let volunteerProfile = selectedRoles.contains(.volunteer) ? buildVolunteerProfile() : nil
+        let organizerProfile = selectedRoles.contains(.organizer) ? buildOrganizerProfile(orgId: orgId) : nil
+        let now = Date()
+
+        return AppUser(
+            id: userId,
+            displayName: trimmedName,
+            pronouns: trimmedPronouns.isEmpty ? nil : trimmedPronouns,
+            photoURL: nil,
+            roles: Array(selectedRoles),
+            status: .active,
+            visibility: visibility,
+            contact: contact,
+            volunteerProfile: volunteerProfile,
+            organizerProfile: organizerProfile,
+            impactSummary: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    func prefillIfNeeded(from user: AppUser?) {
+        guard let user, !hasPrefilled else { return }
+        hasPrefilled = true
+        displayName = user.displayName
+        pronouns = user.pronouns ?? ""
+        email = user.contact?.email ?? ""
+        phone = user.contact?.phone ?? ""
+        preferredChannel = user.contact?.preferredChannel ?? .email
+        shareEmail = user.visibility.shareEmail
+        sharePhone = user.visibility.sharePhone
+        sharePronouns = user.visibility.sharePronouns
+        shareAccessibility = user.visibility.shareAccessibility
+        selectedRoles = Set(user.roles)
+
+        if let profile = user.volunteerProfile {
+            volunteerInterests = Set(profile.interests)
+            volunteerSkills = Set(profile.skills)
+            accessibilityNeeds = profile.accessibilityNeeds?.joined(separator: ", ") ?? ""
+            if let availability = profile.availability, let window = availability.weekly.first?.windows.first {
+                volunteerWeekdays = Set(availability.weekly.map { $0.weekday })
+                volunteerPeriod = periodForWindow(window)
+            }
+        }
+
+        if let organizer = user.organizerProfile {
+            organizerRoleTitle = organizer.contactRole ?? ""
+        }
+    }
+
+    func buildOrganization(ownerId: String) -> Organization? {
+        guard selectedRoles.contains(.organizer) else { return nil }
+        let trimmedName = organizationName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return nil }
+        let now = Date()
+        return Organization(
+            id: "org-\(UUID().uuidString)",
+            name: trimmedName,
+            mission: organizationMission.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : organizationMission,
+            website: organizationWebsite.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : organizationWebsite,
+            location: nil,
+            contact: nil,
+            verified: false,
+            ownerUid: ownerId,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    func setError(_ message: String) {
+        errorMessage = message
+    }
+
+    func clearError() {
+        errorMessage = nil
+    }
+
+    private func buildVolunteerProfile() -> VolunteerProfile {
+        let interests = Array(volunteerInterests)
+        let skills = Array(volunteerSkills)
+        let availability = buildAvailability()
+        let accessibility = accessibilityNeeds.trimmingCharacters(in: .whitespacesAndNewlines)
+        return VolunteerProfile(
+            interests: interests,
+            skills: skills,
+            availability: availability,
+            accessibilityNeeds: accessibility.isEmpty ? nil : [accessibility],
+            location: nil,
+            bio: nil,
+            experienceNotes: nil
+        )
+    }
+
+    private func buildOrganizerProfile(orgId: String?) -> OrganizerProfile {
+        let role = organizerRoleTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        return OrganizerProfile(
+            orgIds: orgId.map { [$0] } ?? [],
+            contactRole: role.isEmpty ? nil : role,
+            verified: false
+        )
+    }
+
+    private func buildAvailability() -> Availability? {
+        guard !volunteerWeekdays.isEmpty else { return nil }
+        let windows = [volunteerPeriod.window]
+        let weekly = volunteerWeekdays.sorted(by: { $0.rawValue < $1.rawValue }).map { day in
+            WeekdayAvailability(weekday: day, windows: windows)
+        }
+        return Availability(timezone: TimeZone.current.identifier, weekly: weekly)
+    }
+
+    private func periodForWindow(_ window: TimeWindow) -> OnboardingAvailabilityPeriod {
+        let mid = (window.startMinutes + window.endMinutes) / 2
+        switch mid {
+        case ..<12 * 60:
+            return .morning
+        case ..<17 * 60:
+            return .afternoon
+        default:
+            return .evening
+        }
+    }
+}

--- a/VolunQueer/VolunQueer/ViewModels/OnboardingViewModel.swift
+++ b/VolunQueer/VolunQueer/ViewModels/OnboardingViewModel.swift
@@ -214,9 +214,9 @@ final class OnboardingViewModel: ObservableObject {
     private func periodForWindow(_ window: TimeWindow) -> OnboardingAvailabilityPeriod {
         let mid = (window.startMinutes + window.endMinutes) / 2
         switch mid {
-        case ..<12 * 60:
+        case ..<(12 * 60):
             return .morning
-        case ..<17 * 60:
+        case ..<(17 * 60):
             return .afternoon
         default:
             return .evening

--- a/VolunQueer/VolunQueer/Views/Components/SelectableChipView.swift
+++ b/VolunQueer/VolunQueer/Views/Components/SelectableChipView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// A tappable chip used for multi-select lists.
+struct SelectableChipView: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(isSelected ? Theme.softCharcoal : Theme.softCharcoal.opacity(0.8))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Theme.lavenderMist : Color(.systemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Theme.lavenderMist, lineWidth: 1)
+                )
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingBasicsStepView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingBasicsStepView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Step for basic profile and consent settings.
+struct OnboardingBasicsStepView: View {
+    @Binding var displayName: String
+    @Binding var pronouns: String
+    @Binding var email: String
+    @Binding var phone: String
+    @Binding var preferredChannel: ContactChannel
+    @Binding var shareEmail: Bool
+    @Binding var sharePhone: Bool
+    @Binding var sharePronouns: Bool
+    @Binding var shareAccessibility: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("Display name", text: $displayName)
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("Pronouns (optional)", text: $pronouns)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("Email", text: $email)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("Phone (optional)", text: $phone)
+                    .keyboardType(.phonePad)
+                    .textFieldStyle(.roundedBorder)
+
+                Picker("Preferred contact", selection: $preferredChannel) {
+                    Text("Email").tag(ContactChannel.email)
+                    Text("SMS").tag(ContactChannel.sms)
+                    Text("Push").tag(ContactChannel.push)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("What organizers can see")
+                    .font(.headline)
+                    .foregroundStyle(Theme.softCharcoal)
+
+                Toggle("Share email", isOn: $shareEmail)
+                Toggle("Share phone", isOn: $sharePhone)
+                Toggle("Share pronouns", isOn: $sharePronouns)
+                Toggle("Share accessibility needs", isOn: $shareAccessibility)
+            }
+            .font(.caption)
+
+            Text("You can change this later. We only share what you explicitly allow.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingDoneStepView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingDoneStepView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Confirmation step for onboarding.
+struct OnboardingDoneStepView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Welcome to VolunQueer!")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(Theme.softCharcoal)
+
+            Text("You’re ready to discover events, RSVP quickly, and show up with confidence.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Browse events that match your interests", systemImage: "sparkles")
+                Label("Keep track of RSVPs in one place", systemImage: "checklist")
+                Label("Update your profile anytime", systemImage: "person.crop.circle")
+            }
+            .font(.caption)
+            .foregroundStyle(Theme.softCharcoal)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingFlowView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingFlowView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+/// Handles the multi-step onboarding flow.
+struct OnboardingFlowView: View {
+    @EnvironmentObject private var store: AppStore
+    @StateObject private var viewModel = OnboardingViewModel()
+
+    let userId: String
+
+    var body: some View {
+        VStack(spacing: 24) {
+            header
+
+            ScrollView {
+                VStack(spacing: 20) {
+                    stepView
+                    if let message = viewModel.errorMessage {
+                        Text(message)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.horizontal)
+            }
+
+            footer
+        }
+        .padding(.vertical)
+        .background(Theme.cream)
+        .onAppear {
+            viewModel.prefillIfNeeded(from: store.user(for: userId))
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ProgressView(value: viewModel.progressValue)
+                .tint(Theme.coralRose)
+
+            Text(viewModel.currentStep.title)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(Theme.softCharcoal)
+
+            Text(viewModel.currentStep.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal)
+    }
+
+    @ViewBuilder
+    private var stepView: some View {
+        switch viewModel.currentStep {
+        case .role:
+            OnboardingRoleStepView(selectedRoles: $viewModel.selectedRoles)
+        case .basics:
+            OnboardingBasicsStepView(
+                displayName: $viewModel.displayName,
+                pronouns: $viewModel.pronouns,
+                email: $viewModel.email,
+                phone: $viewModel.phone,
+                preferredChannel: $viewModel.preferredChannel,
+                shareEmail: $viewModel.shareEmail,
+                sharePhone: $viewModel.sharePhone,
+                sharePronouns: $viewModel.sharePronouns,
+                shareAccessibility: $viewModel.shareAccessibility
+            )
+        case .volunteer:
+            OnboardingVolunteerStepView(
+                interests: $viewModel.volunteerInterests,
+                skills: $viewModel.volunteerSkills,
+                weekdays: $viewModel.volunteerWeekdays,
+                period: $viewModel.volunteerPeriod,
+                accessibilityNeeds: $viewModel.accessibilityNeeds
+            )
+        case .organizer:
+            OnboardingOrganizerStepView(
+                organizationName: $viewModel.organizationName,
+                organizerRoleTitle: $viewModel.organizerRoleTitle,
+                organizationMission: $viewModel.organizationMission,
+                organizationWebsite: $viewModel.organizationWebsite
+            )
+        case .done:
+            OnboardingDoneStepView()
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            if viewModel.currentStepIndex > 0 {
+                Button("Back") {
+                    viewModel.back()
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Spacer()
+
+            Button(viewModel.currentStep == .done ? "Finish" : "Next") {
+                Task { await handleNext() }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.canAdvance() || viewModel.isSaving)
+        }
+        .padding(.horizontal)
+    }
+
+    private func handleNext() async {
+        viewModel.clearError()
+        if viewModel.currentStep == .done {
+            await completeOnboarding()
+        } else {
+            viewModel.advance()
+        }
+    }
+
+    private func completeOnboarding() async {
+        viewModel.isSaving = true
+        do {
+            let existingUser = store.user(for: userId)
+            let organization = viewModel.buildOrganization(ownerId: userId)
+            if let organization {
+                try await store.saveOrganization(organization)
+                var user = viewModel.buildUser(userId: userId, orgId: organization.id)
+                if let existingUser {
+                    user.createdAt = existingUser.createdAt
+                    user.photoURL = existingUser.photoURL
+                    user.impactSummary = existingUser.impactSummary
+                }
+                try await store.saveUser(user)
+            } else {
+                var user = viewModel.buildUser(userId: userId, orgId: nil)
+                if let existingUser {
+                    user.createdAt = existingUser.createdAt
+                    user.photoURL = existingUser.photoURL
+                    user.impactSummary = existingUser.impactSummary
+                }
+                try await store.saveUser(user)
+            }
+        } catch {
+            viewModel.setError(error.localizedDescription)
+        }
+        viewModel.isSaving = false
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingOrganizerStepView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingOrganizerStepView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Step for organizer and organization details.
+struct OnboardingOrganizerStepView: View {
+    @Binding var organizationName: String
+    @Binding var organizerRoleTitle: String
+    @Binding var organizationMission: String
+    @Binding var organizationWebsite: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            TextField("Organization name", text: $organizationName)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Your role (optional)", text: $organizerRoleTitle)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Mission (optional)", text: $organizationMission)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Website (optional)", text: $organizationWebsite)
+                .textInputAutocapitalization(.never)
+                .textFieldStyle(.roundedBorder)
+
+            Text("You can fill out more details later.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingRoleStepView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingRoleStepView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Step for choosing volunteer and/or organizer roles.
+struct OnboardingRoleStepView: View {
+    @Binding var selectedRoles: Set<UserRole>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("How do you want to participate?")
+                .font(.headline)
+                .foregroundStyle(Theme.softCharcoal)
+
+            VStack(spacing: 12) {
+                roleCard(
+                    title: "Volunteer",
+                    subtitle: "Discover events, RSVP fast, and track your impact.",
+                    role: .volunteer
+                )
+
+                roleCard(
+                    title: "Organizer",
+                    subtitle: "Post events, manage rosters, and support volunteers.",
+                    role: .organizer
+                )
+            }
+
+            Text("You can change this later in your profile.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func roleCard(title: String, subtitle: String, role: UserRole) -> some View {
+        let isSelected = selectedRoles.contains(role)
+        return Button {
+            toggle(role)
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? Theme.skyTeal : .secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(Theme.softCharcoal)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? Theme.lavenderMist : Color(.systemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func toggle(_ role: UserRole) {
+        if selectedRoles.contains(role) {
+            selectedRoles.remove(role)
+        } else {
+            selectedRoles.insert(role)
+        }
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Onboarding/OnboardingVolunteerStepView.swift
+++ b/VolunQueer/VolunQueer/Views/Onboarding/OnboardingVolunteerStepView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// Step for volunteer interests, skills, and availability.
+struct OnboardingVolunteerStepView: View {
+    @Binding var interests: Set<String>
+    @Binding var skills: Set<String>
+    @Binding var weekdays: Set<Weekday>
+    @Binding var period: OnboardingAvailabilityPeriod
+    @Binding var accessibilityNeeds: String
+
+    private let interestOptions = [
+        "Community", "Mutual aid", "Youth", "Arts", "Health", "Housing", "Events"
+    ]
+    private let skillOptions = [
+        "Setup", "Hospitality", "Outreach", "Logistics", "Tech", "Translation"
+    ]
+    private let columns = [GridItem(.adaptive(minimum: 110), spacing: 8)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("Interests")
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                ForEach(interestOptions, id: \.self) { option in
+                    SelectableChipView(
+                        title: option,
+                        isSelected: interests.contains(option)
+                    ) {
+                        toggle(option, in: &interests)
+                    }
+                }
+            }
+
+            sectionHeader("Skills")
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                ForEach(skillOptions, id: \.self) { option in
+                    SelectableChipView(
+                        title: option,
+                        isSelected: skills.contains(option)
+                    ) {
+                        toggle(option, in: &skills)
+                    }
+                }
+            }
+
+            sectionHeader("Availability")
+            VStack(alignment: .leading, spacing: 12) {
+                LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                    ForEach(Weekday.allCases, id: \.self) { day in
+                        SelectableChipView(
+                            title: dayLabel(day),
+                            isSelected: weekdays.contains(day)
+                        ) {
+                            toggle(day, in: &weekdays)
+                        }
+                    }
+                }
+
+                Picker("Time of day", selection: $period) {
+                    ForEach(OnboardingAvailabilityPeriod.allCases) { option in
+                        Text(option.label).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            sectionHeader("Accessibility needs (optional)")
+            TextField("Anything organizers should know?", text: $accessibilityNeeds)
+                .textFieldStyle(.roundedBorder)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.headline)
+            .foregroundStyle(Theme.softCharcoal)
+    }
+
+    private func toggle(_ value: String, in set: inout Set<String>) {
+        if set.contains(value) {
+            set.remove(value)
+        } else {
+            set.insert(value)
+        }
+    }
+
+    private func toggle(_ value: Weekday, in set: inout Set<Weekday>) {
+        if set.contains(value) {
+            set.remove(value)
+        } else {
+            set.insert(value)
+        }
+    }
+
+    private func dayLabel(_ day: Weekday) -> String {
+        switch day {
+        case .monday: return "Mon"
+        case .tuesday: return "Tue"
+        case .wednesday: return "Wed"
+        case .thursday: return "Thu"
+        case .friday: return "Fri"
+        case .saturday: return "Sat"
+        case .sunday: return "Sun"
+        }
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Profile/ProfileEditView.swift
+++ b/VolunQueer/VolunQueer/Views/Profile/ProfileEditView.swift
@@ -262,9 +262,9 @@ struct ProfileEditView: View {
     private func periodForWindow(_ window: TimeWindow) -> OnboardingAvailabilityPeriod {
         let mid = (window.startMinutes + window.endMinutes) / 2
         switch mid {
-        case ..<12 * 60:
+        case ..<(12 * 60):
             return .morning
-        case ..<17 * 60:
+        case ..<(17 * 60):
             return .afternoon
         default:
             return .evening

--- a/VolunQueer/VolunQueer/Views/Profile/ProfileEditView.swift
+++ b/VolunQueer/VolunQueer/Views/Profile/ProfileEditView.swift
@@ -1,0 +1,282 @@
+import SwiftUI
+
+/// Form for editing the current user's profile.
+struct ProfileEditView: View {
+    @EnvironmentObject private var store: AppStore
+    @Environment(\.dismiss) private var dismiss
+
+    let userId: String
+
+    @State private var displayName: String = ""
+    @State private var pronouns: String = ""
+    @State private var email: String = ""
+    @State private var phone: String = ""
+    @State private var preferredChannel: ContactChannel = .email
+    @State private var shareEmail: Bool = true
+    @State private var sharePhone: Bool = false
+    @State private var sharePronouns: Bool = true
+    @State private var shareAccessibility: Bool = true
+
+    @State private var interests: Set<String> = []
+    @State private var skills: Set<String> = []
+    @State private var weekdays: Set<Weekday> = []
+    @State private var period: OnboardingAvailabilityPeriod = .evening
+    @State private var accessibilityNeeds: String = ""
+
+    @State private var organizerRoleTitle: String = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    private let interestOptions = [
+        "Community", "Mutual aid", "Youth", "Arts", "Health", "Housing", "Events"
+    ]
+    private let skillOptions = [
+        "Setup", "Hospitality", "Outreach", "Logistics", "Tech", "Translation"
+    ]
+    private let columns = [GridItem(.adaptive(minimum: 110), spacing: 8)]
+
+    var body: some View {
+        Form {
+            if let user = store.user(for: userId) {
+                Section("Basics") {
+                    TextField("Display name", text: $displayName)
+                    TextField("Pronouns", text: $pronouns)
+                }
+
+                Section("Contact") {
+                    TextField("Email", text: $email)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Phone", text: $phone)
+                        .keyboardType(.phonePad)
+
+                    Picker("Preferred contact", selection: $preferredChannel) {
+                        Text("Email").tag(ContactChannel.email)
+                        Text("SMS").tag(ContactChannel.sms)
+                        Text("Push").tag(ContactChannel.push)
+                    }
+                }
+
+                Section("Organizer visibility") {
+                    Toggle("Share email", isOn: $shareEmail)
+                    Toggle("Share phone", isOn: $sharePhone)
+                    Toggle("Share pronouns", isOn: $sharePronouns)
+                    Toggle("Share accessibility needs", isOn: $shareAccessibility)
+                }
+
+                if user.roles.contains(.volunteer) {
+                    Section("Volunteer profile") {
+                        Text("Interests")
+                            .font(.caption)
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                            ForEach(interestOptions, id: \.self) { option in
+                                SelectableChipView(
+                                    title: option,
+                                    isSelected: interests.contains(option)
+                                ) {
+                                    toggle(option, in: &interests)
+                                }
+                            }
+                        }
+
+                        Text("Skills")
+                            .font(.caption)
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                            ForEach(skillOptions, id: \.self) { option in
+                                SelectableChipView(
+                                    title: option,
+                                    isSelected: skills.contains(option)
+                                ) {
+                                    toggle(option, in: &skills)
+                                }
+                            }
+                        }
+
+                        Text("Availability")
+                            .font(.caption)
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                            ForEach(Weekday.allCases, id: \.self) { day in
+                                SelectableChipView(
+                                    title: dayLabel(day),
+                                    isSelected: weekdays.contains(day)
+                                ) {
+                                    toggle(day, in: &weekdays)
+                                }
+                            }
+                        }
+
+                        Picker("Time of day", selection: $period) {
+                            ForEach(OnboardingAvailabilityPeriod.allCases) { option in
+                                Text(option.label).tag(option)
+                            }
+                        }
+
+                        TextField("Accessibility needs", text: $accessibilityNeeds)
+                    }
+                }
+
+                if user.roles.contains(.organizer) {
+                    Section("Organizer profile") {
+                        TextField("Your role", text: $organizerRoleTitle)
+                        if let organizer = user.organizerProfile {
+                            let names = organizer.orgIds.compactMap { id in
+                                store.organizations.first { $0.id == id }?.name
+                            }
+                            Text("Organizations: \(names.joined(separator: ", "))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if let message = errorMessage {
+                    Section {
+                        Text(message)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Edit Profile")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Save") {
+                    Task { await saveProfile() }
+                }
+                .disabled(isSaving)
+            }
+        }
+        .onAppear(perform: loadProfile)
+    }
+
+    private func loadProfile() {
+        guard let user = store.user(for: userId) else { return }
+        displayName = user.displayName
+        pronouns = user.pronouns ?? ""
+        email = user.contact?.email ?? ""
+        phone = user.contact?.phone ?? ""
+        preferredChannel = user.contact?.preferredChannel ?? .email
+        shareEmail = user.visibility.shareEmail
+        sharePhone = user.visibility.sharePhone
+        sharePronouns = user.visibility.sharePronouns
+        shareAccessibility = user.visibility.shareAccessibility
+
+        if let profile = user.volunteerProfile {
+            interests = Set(profile.interests)
+            skills = Set(profile.skills)
+            accessibilityNeeds = profile.accessibilityNeeds?.joined(separator: ", ") ?? ""
+            if let availability = profile.availability {
+                weekdays = Set(availability.weekly.map { $0.weekday })
+                if let window = availability.weekly.first?.windows.first {
+                    period = periodForWindow(window)
+                }
+            }
+        }
+
+        if let organizer = user.organizerProfile {
+            organizerRoleTitle = organizer.contactRole ?? ""
+        }
+    }
+
+    private func saveProfile() async {
+        guard var user = store.user(for: userId) else { return }
+        isSaving = true
+        errorMessage = nil
+
+        user.displayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        user.pronouns = pronouns.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : pronouns
+        user.contact = ContactInfo(
+            email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+            phone: phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : phone,
+            preferredChannel: preferredChannel
+        )
+        user.visibility = UserVisibility(
+            shareEmail: shareEmail,
+            sharePhone: sharePhone,
+            sharePronouns: sharePronouns,
+            shareAccessibility: shareAccessibility
+        )
+
+        if user.roles.contains(.volunteer) {
+            let availability = buildAvailability()
+            let access = accessibilityNeeds.trimmingCharacters(in: .whitespacesAndNewlines)
+            user.volunteerProfile = VolunteerProfile(
+                interests: Array(interests),
+                skills: Array(skills),
+                availability: availability,
+                accessibilityNeeds: access.isEmpty ? nil : [access],
+                location: user.volunteerProfile?.location,
+                bio: user.volunteerProfile?.bio,
+                experienceNotes: user.volunteerProfile?.experienceNotes
+            )
+        }
+
+        if user.roles.contains(.organizer) {
+            let role = organizerRoleTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            var organizer = user.organizerProfile ?? OrganizerProfile(orgIds: [], contactRole: nil, verified: false)
+            organizer.contactRole = role.isEmpty ? nil : role
+            user.organizerProfile = organizer
+        }
+
+        user.updatedAt = Date()
+
+        do {
+            try await store.saveUser(user)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isSaving = false
+    }
+
+    private func toggle(_ value: String, in set: inout Set<String>) {
+        if set.contains(value) {
+            set.remove(value)
+        } else {
+            set.insert(value)
+        }
+    }
+
+    private func toggle(_ value: Weekday, in set: inout Set<Weekday>) {
+        if set.contains(value) {
+            set.remove(value)
+        } else {
+            set.insert(value)
+        }
+    }
+
+    private func dayLabel(_ day: Weekday) -> String {
+        switch day {
+        case .monday: return "Mon"
+        case .tuesday: return "Tue"
+        case .wednesday: return "Wed"
+        case .thursday: return "Thu"
+        case .friday: return "Fri"
+        case .saturday: return "Sat"
+        case .sunday: return "Sun"
+        }
+    }
+
+    private func periodForWindow(_ window: TimeWindow) -> OnboardingAvailabilityPeriod {
+        let mid = (window.startMinutes + window.endMinutes) / 2
+        switch mid {
+        case ..<12 * 60:
+            return .morning
+        case ..<17 * 60:
+            return .afternoon
+        default:
+            return .evening
+        }
+    }
+
+    private func buildAvailability() -> Availability? {
+        guard !weekdays.isEmpty else { return nil }
+        let windows = [period.window]
+        let weekly = weekdays.sorted(by: { $0.rawValue < $1.rawValue }).map { day in
+            WeekdayAvailability(weekday: day, windows: windows)
+        }
+        return Availability(timezone: TimeZone.current.identifier, weekly: weekly)
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
+++ b/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Profile summary with navigation to editing.
+struct ProfileView: View {
+    @EnvironmentObject private var store: AppStore
+    let userId: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if let user = store.user(for: userId) {
+                    header(for: user)
+                    contactCard(for: user)
+                    if user.roles.contains(.volunteer) {
+                        volunteerCard(for: user)
+                    }
+                    if user.roles.contains(.organizer) {
+                        organizerCard(for: user)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "Profile unavailable",
+                        systemImage: "person.crop.circle.badge.exclam",
+                        description: Text("We couldn't find your profile yet.")
+                    )
+                }
+            }
+            .padding()
+        }
+        .background(Theme.cream)
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink("Edit") {
+                    ProfileEditView(userId: userId)
+                }
+            }
+        }
+    }
+
+    private func header(for user: AppUser) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(user.displayName)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(Theme.softCharcoal)
+
+            if let pronouns = user.pronouns, !pronouns.isEmpty {
+                Text(pronouns)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(user.roles.map { $0.rawValue.capitalized }.joined(separator: " • "))
+                .font(.caption)
+                .foregroundStyle(Theme.skyTeal)
+        }
+    }
+
+    private func contactCard(for user: AppUser) -> some View {
+        let contact = user.contact
+        return cardView(title: "Contact") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(contact?.email ?? "Email not set")
+                Text(contact?.phone ?? "Phone not set")
+                if let channel = contact?.preferredChannel {
+                    Text("Preferred: \(channel.rawValue.uppercased())")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(Theme.softCharcoal)
+        }
+    }
+
+    private func volunteerCard(for user: AppUser) -> some View {
+        cardView(title: "Volunteer profile") {
+            if let profile = user.volunteerProfile {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Interests: \(profile.interests.joined(separator: ", "))")
+                    Text("Skills: \(profile.skills.joined(separator: ", "))")
+                    Text("Availability: \(availabilitySummary(profile.availability))")
+                    if let needs = profile.accessibilityNeeds?.joined(separator: ", "), !needs.isEmpty {
+                        Text("Accessibility: \(needs)")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(Theme.softCharcoal)
+            } else {
+                Text("Complete your volunteer details.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func organizerCard(for user: AppUser) -> some View {
+        cardView(title: "Organizer profile") {
+            VStack(alignment: .leading, spacing: 6) {
+                if let profile = user.organizerProfile {
+                    if !profile.orgIds.isEmpty {
+                        let names = profile.orgIds.compactMap { id in
+                            store.organizations.first { $0.id == id }?.name
+                        }
+                        Text("Organizations: \(names.isEmpty ? "Not set" : names.joined(separator: ", "))")
+                    }
+                    if let role = profile.contactRole, !role.isEmpty {
+                        Text("Role: \(role)")
+                    }
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(Theme.softCharcoal)
+        }
+    }
+
+    private func cardView(title: String, content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(Theme.softCharcoal)
+            content()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func availabilitySummary(_ availability: Availability?) -> String {
+        guard let availability else { return "Not set" }
+        let days = availability.weekly.map { $0.weekday.rawValue.prefix(3).capitalized }
+        if days.isEmpty { return "Not set" }
+        return days.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfileView(userId: "user-alex")
+            .environmentObject(AppStore(dataSource: .mock, preload: true))
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
+++ b/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
@@ -110,7 +110,7 @@ struct ProfileView: View {
         }
     }
 
-    private func cardView(title: String, content: () -> some View) -> some View {
+    private func cardView<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.headline)
@@ -144,3 +144,4 @@ struct ProfileView: View {
             .environmentObject(AppStore(dataSource: .mock, preload: true))
     }
 }
+

--- a/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
+++ b/VolunQueer/VolunQueer/Views/Profile/ProfileView.swift
@@ -98,10 +98,7 @@ struct ProfileView: View {
             VStack(alignment: .leading, spacing: 6) {
                 if let profile = user.organizerProfile {
                     if !profile.orgIds.isEmpty {
-                        let names = profile.orgIds.compactMap { id in
-                            store.organizations.first { $0.id == id }?.name
-                        }
-                        Text("Organizations: \(names.isEmpty ? "Not set" : names.joined(separator: ", "))")
+                        Text("Organizations: \(organizationSummary(profile))")
                     }
                     if let role = profile.contactRole, !role.isEmpty {
                         Text("Role: \(role)")
@@ -131,6 +128,13 @@ struct ProfileView: View {
         let days = availability.weekly.map { $0.weekday.rawValue.prefix(3).capitalized }
         if days.isEmpty { return "Not set" }
         return days.joined(separator: ", ")
+    }
+
+    private func organizationSummary(_ profile: OrganizerProfile) -> String {
+        let names = profile.orgIds.compactMap { id in
+            store.organizations.first { $0.id == id }?.name
+        }
+        return names.isEmpty ? "Not set" : names.joined(separator: ", ")
     }
 }
 

--- a/VolunQueer/VolunQueer/Views/Tabs/ProfileTabView.swift
+++ b/VolunQueer/VolunQueer/Views/Tabs/ProfileTabView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Tab wrapper for profile viewing and editing.
+struct ProfileTabView: View {
+    @EnvironmentObject private var store: AppStore
+    @EnvironmentObject private var authStore: AuthStore
+
+    let userId: String
+
+    var body: some View {
+        NavigationStack {
+            ProfileView(userId: userId)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Reload") {
+                            Task { await store.load() }
+                        }
+                    }
+
+                    if store.dataSource == .firestore {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button("Seed Firestore") {
+                                Task { await store.seedMockData() }
+                            }
+                        }
+                    }
+
+                    ToolbarItem(placement: .bottomBar) {
+                        Button("Sign Out") {
+                            authStore.signOut()
+                        }
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
 Title
  Profiles + onboarding flow (volunteer + organizer)

  Body

  ## Summary

  - Added multi‑step onboarding (role → basics/consent → volunteer + organizer profiles → done) and gated the app until completion.
  - Added Profile tab with summary + edit screens for volunteers and organizers.
  - Persisted users/organizations via AppStore for mock + Firestore.
  - Added reusable chip UI for multi‑select interests/skills.

  ## Testing

  - [ ] Manual: sign in → onboarding flow completes → app tabs show
  - [ ] Manual: Profile tab shows volunteer + organizer sections
  - [ ] Manual: Edit profile saves and reflects on Profile

  ## Notes

  - GoogleService‑Info.plist remains untracked as intended.
  - VolunQueer.xcodeproj/xcshareddata/ left uncommitted.