### PR TITLE
Add organizer event editing and multi-role management

### DIFF
--- a/VolunQueer/VolunQueer/Data/FirestoreClient.swift
+++ b/VolunQueer/VolunQueer/Data/FirestoreClient.swift
@@ -74,6 +74,19 @@ final class FirestoreClient {
         }
     }
 
+    /// Deletes a document by ID.
+    func deleteDocument(_ collectionPath: String, id: String) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            db.collection(collectionPath).document(id).delete { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
     /// Seeds Firestore with a mock data bundle.
     func seed(bundle: MockDataBundle) async throws {
         for user in bundle.users {

--- a/VolunQueer/VolunQueer/ViewModels/EventDraft.swift
+++ b/VolunQueer/VolunQueer/ViewModels/EventDraft.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Draft state and builders for organizer event creation.
+struct EventDraft {
+    var title: String = ""
+    var description: String = ""
+    var startsAt: Date
+    var endsAt: Date
+    var timezone: String = TimeZone.current.identifier
+
+    var locationName: String = ""
+    var locationAddress: String = ""
+    var locationCity: String = ""
+    var locationRegion: String = ""
+    var locationPostalCode: String = ""
+    var locationCountry: String = ""
+
+    var accessibilityNotes: String = ""
+    var accessibilityTags: String = ""
+    var tags: String = ""
+
+    var rsvpCapEnabled: Bool = false
+    var rsvpCap: Int = 20
+
+    var contactName: String = ""
+    var contactEmail: String = ""
+    var contactPhone: String = ""
+
+    var roles: [EventRoleDraft]
+
+    var status: EventStatus = .published
+
+    init(now: Date = Date()) {
+        startsAt = now
+        endsAt = now.addingTimeInterval(60 * 60)
+        roles = [EventRoleDraft()]
+    }
+
+    init(event: Event, roles: [EventRole]) {
+        title = event.title
+        description = event.description ?? ""
+        startsAt = event.startsAt
+        endsAt = event.endsAt
+        timezone = event.timezone
+        locationName = event.location.name ?? ""
+        locationAddress = event.location.address ?? ""
+        locationCity = event.location.city ?? ""
+        locationRegion = event.location.region ?? ""
+        locationPostalCode = event.location.postalCode ?? ""
+        locationCountry = event.location.country ?? ""
+        accessibilityNotes = event.accessibility?.notes ?? ""
+        accessibilityTags = event.accessibility?.tags?.joined(separator: ", ") ?? ""
+        tags = event.tags.joined(separator: ", ")
+        if let cap = event.rsvpCap {
+            rsvpCapEnabled = true
+            rsvpCap = cap
+        } else {
+            rsvpCapEnabled = false
+            rsvpCap = 20
+        }
+        contactName = event.contact?.name ?? ""
+        contactEmail = event.contact?.email ?? ""
+        contactPhone = event.contact?.phone ?? ""
+        status = event.status
+        self.roles = roles.isEmpty ? [EventRoleDraft()] : roles.map { EventRoleDraft(role: $0) }
+    }
+
+    var validationMessage: String? {
+        if title.trimmed.isEmpty {
+            return "Add an event title."
+        }
+        if startsAt >= endsAt {
+            return "End time must be after the start time."
+        }
+        if locationName.trimmed.isEmpty
+            && locationAddress.trimmed.isEmpty
+            && locationCity.trimmed.isEmpty
+            && locationRegion.trimmed.isEmpty
+            && locationPostalCode.trimmed.isEmpty
+            && locationCountry.trimmed.isEmpty {
+            return "Add a location for the event."
+        }
+        if rsvpCapEnabled && rsvpCap < 1 {
+            return "RSVP cap must be at least 1."
+        }
+        if roles.isEmpty {
+            return "Add at least one role."
+        }
+        if let roleIssue = roles.first(where: { $0.validationMessage != nil }) {
+            return roleIssue.validationMessage
+        }
+        return nil
+    }
+
+    var canSubmit: Bool {
+        validationMessage == nil
+    }
+
+    func buildEvent(userId: String, orgId: String, eventId: String? = nil, createdAt: Date? = nil, createdBy: String? = nil) -> (Event, [EventRole]) {
+        let now = Date()
+        let resolvedEventId = eventId ?? "event-\(UUID().uuidString)"
+        let resolvedCreatedAt = createdAt ?? now
+
+        let event = Event(
+            id: resolvedEventId,
+            orgId: orgId,
+            title: title.trimmed,
+            description: description.trimmed.nilIfEmpty,
+            startsAt: startsAt,
+            endsAt: endsAt,
+            timezone: timezone.trimmed.isEmpty ? TimeZone.current.identifier : timezone.trimmed,
+            location: LocationInfo(
+                name: locationName.trimmed.nilIfEmpty,
+                address: locationAddress.trimmed.nilIfEmpty,
+                city: locationCity.trimmed.nilIfEmpty,
+                region: locationRegion.trimmed.nilIfEmpty,
+                postalCode: locationPostalCode.trimmed.nilIfEmpty,
+                country: locationCountry.trimmed.nilIfEmpty,
+                geo: nil
+            ),
+            accessibility: buildAccessibility(),
+            tags: parseTags(tags),
+            rsvpCap: rsvpCapEnabled ? max(1, rsvpCap) : nil,
+            status: status,
+            contact: buildContact(),
+            createdBy: createdBy ?? userId,
+            createdAt: resolvedCreatedAt,
+            updatedAt: now
+        )
+
+        let builtRoles = roles.map { $0.buildRole() }
+
+        return (event, builtRoles)
+    }
+
+    private func buildAccessibility() -> AccessibilityInfo? {
+        let notes = accessibilityNotes.trimmed.nilIfEmpty
+        let tags = parseTags(accessibilityTags)
+        guard notes != nil || !tags.isEmpty else { return nil }
+        return AccessibilityInfo(notes: notes, tags: tags.isEmpty ? nil : tags)
+    }
+
+    private func buildContact() -> EventContact? {
+        let name = contactName.trimmed.nilIfEmpty
+        let email = contactEmail.trimmed.nilIfEmpty
+        let phone = contactPhone.trimmed.nilIfEmpty
+        guard name != nil || email != nil || phone != nil else { return nil }
+        return EventContact(name: name, email: email, phone: phone)
+    }
+
+    private func parseTags(_ text: String) -> [String] {
+        text
+            .split(whereSeparator: { $0 == "," || $0 == "\n" })
+            .map { String($0).trimmed }
+            .filter { !$0.isEmpty }
+    }
+}
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var nilIfEmpty: String? {
+        let value = trimmed
+        return value.isEmpty ? nil : value
+    }
+}

--- a/VolunQueer/VolunQueer/ViewModels/EventRoleDraft.swift
+++ b/VolunQueer/VolunQueer/ViewModels/EventRoleDraft.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Draft state for editing an event role.
+struct EventRoleDraft: Identifiable, Hashable {
+    var id: String
+    var title: String
+    var description: String
+    var slotsTotal: Int
+    var slotsFilled: Int
+    var skills: String
+    var checkInRequired: Bool
+    var minAgeEnabled: Bool
+    var minAge: Int
+
+    init() {
+        id = "role-\(UUID().uuidString)"
+        title = "Volunteer"
+        description = ""
+        slotsTotal = 6
+        slotsFilled = 0
+        skills = ""
+        checkInRequired = false
+        minAgeEnabled = false
+        minAge = 18
+    }
+
+    init(role: EventRole) {
+        id = role.id
+        title = role.title
+        description = role.description ?? ""
+        slotsTotal = role.slotsTotal
+        slotsFilled = role.slotsFilled
+        skills = role.skillsRequired.joined(separator: ", ")
+        checkInRequired = role.checkInRequired
+        if let minAge = role.minAge {
+            minAgeEnabled = true
+            self.minAge = minAge
+        } else {
+            minAgeEnabled = false
+            minAge = 18
+        }
+    }
+
+    var validationMessage: String? {
+        if title.trimmed.isEmpty {
+            return "Add a role title."
+        }
+        if slotsTotal < max(1, slotsFilled) {
+            return "Slots must be at least \(max(1, slotsFilled))."
+        }
+        if minAgeEnabled && minAge < 1 {
+            return "Minimum age must be at least 1."
+        }
+        return nil
+    }
+
+    func buildRole() -> EventRole {
+        EventRole(
+            id: id,
+            title: title.trimmed,
+            description: description.trimmed.nilIfEmpty,
+            slotsTotal: max(slotsTotal, max(1, slotsFilled)),
+            slotsFilled: slotsFilled,
+            skillsRequired: parseTags(skills),
+            checkInRequired: checkInRequired,
+            minAge: minAgeEnabled ? max(1, minAge) : nil
+        )
+    }
+
+    private func parseTags(_ text: String) -> [String] {
+        text
+            .split(whereSeparator: { $0 == "," || $0 == "\n" })
+            .map { String($0).trimmed }
+            .filter { !$0.isEmpty }
+    }
+}
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var nilIfEmpty: String? {
+        let value = trimmed
+        return value.isEmpty ? nil : value
+    }
+}

--- a/VolunQueer/VolunQueer/Views/ContentView.swift
+++ b/VolunQueer/VolunQueer/Views/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
     private func tabView(userId: String) -> some View {
         let user = store.user(for: userId)
         let isVolunteer = user?.roles.contains(.volunteer) ?? true
+        let isOrganizer = user?.roles.contains(.organizer) ?? false
 
         return TabView {
             DiscoverTabView(userId: userId, service: store.rsvpService)
@@ -60,6 +61,13 @@ struct ContentView: View {
                 MyRSVPsTabView(userId: userId, service: store.rsvpService)
                     .tabItem {
                         Label("My RSVPs", systemImage: "checklist")
+                    }
+            }
+
+            if isOrganizer {
+                OrganizerTabView(userId: userId)
+                    .tabItem {
+                        Label("Manage", systemImage: "square.and.pencil")
                     }
             }
 

--- a/VolunQueer/VolunQueer/Views/Events/EventEditorView.swift
+++ b/VolunQueer/VolunQueer/Views/Events/EventEditorView.swift
@@ -1,0 +1,361 @@
+import SwiftUI
+
+/// Form for creating a new organizer event.
+struct EventEditorView: View {
+    @EnvironmentObject private var store: AppStore
+    @Environment(\.dismiss) private var dismiss
+
+    let userId: String
+    let existingEvent: Event?
+
+    @State private var draft: EventDraft
+    @State private var selectedOrgId: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(userId: String, event: Event? = nil, roles: [EventRole] = []) {
+        self.userId = userId
+        existingEvent = event
+        if let event {
+            _draft = State(initialValue: EventDraft(event: event, roles: roles))
+            _selectedOrgId = State(initialValue: event.orgId)
+        } else {
+            _draft = State(initialValue: EventDraft())
+            _selectedOrgId = State(initialValue: "")
+        }
+    }
+
+    var body: some View {
+        Form {
+            organizationSection
+            detailsSection
+            scheduleSection
+            locationSection
+            accessibilitySection
+            rolesSection
+            capacitySection
+            contactSection
+            statusSection
+            submissionSection
+        }
+        .navigationTitle(isEditing ? "Edit Event" : "New Event")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") {
+                    dismiss()
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Theme.cream)
+        .onAppear(perform: prefill)
+        .onChange(of: draft.startsAt) { newValue in
+            let minEnd = newValue.addingTimeInterval(15 * 60)
+            if draft.endsAt < minEnd {
+                draft.endsAt = minEnd
+            }
+        }
+        .onChange(of: availableOrganizations) { orgs in
+            if selectedOrgId.isEmpty, let first = orgs.first {
+                selectedOrgId = first.id
+            }
+        }
+    }
+
+    private var isEditing: Bool {
+        existingEvent != nil
+    }
+
+    private var organizationSection: some View {
+        Section("Organization") {
+            if availableOrganizations.isEmpty {
+                Text("No organizations found. Add one in your organizer profile.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                Picker("Host organization", selection: $selectedOrgId) {
+                    ForEach(availableOrganizations) { org in
+                        Text(org.name).tag(org.id)
+                    }
+                }
+                .disabled(isEditing)
+            }
+        }
+    }
+
+    private var detailsSection: some View {
+        Section("Event details") {
+            TextField("Title", text: $draft.title)
+            TextEditor(text: $draft.description)
+                .frame(minHeight: 80)
+            TextField("Tags (comma separated)", text: $draft.tags)
+        }
+    }
+
+    private var scheduleSection: some View {
+        Section("Schedule") {
+            DatePicker("Starts", selection: $draft.startsAt, displayedComponents: [.date, .hourAndMinute])
+            DatePicker(
+                "Ends",
+                selection: $draft.endsAt,
+                in: draft.startsAt.addingTimeInterval(15 * 60)...Date.distantFuture,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            Text("Timezone: \(draft.timezone)")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var locationSection: some View {
+        Section("Location") {
+            TextField("Location name", text: $draft.locationName)
+            TextField("Address", text: $draft.locationAddress)
+            TextField("City", text: $draft.locationCity)
+            TextField("State / Region", text: $draft.locationRegion)
+            TextField("Postal code", text: $draft.locationPostalCode)
+            TextField("Country", text: $draft.locationCountry)
+        }
+    }
+
+    private var accessibilitySection: some View {
+        Section("Accessibility") {
+            TextEditor(text: $draft.accessibilityNotes)
+                .frame(minHeight: 70)
+            TextField("Tags (comma separated)", text: $draft.accessibilityTags)
+        }
+    }
+
+    private var rolesSection: some View {
+        Section("Roles") {
+            ForEach(Array(draft.roles.enumerated()), id: \.element.id) { index, _ in
+                let roleBinding = $draft.roles[index]
+                let roleValue = draft.roles[index]
+                VStack(alignment: .leading, spacing: 12) {
+                    TextField("Role title", text: roleBinding.title)
+                    TextField("Role description", text: roleBinding.description)
+
+                    Stepper(value: roleBinding.slotsTotal, in: minSlots(for: roleValue)...maxSlots(for: roleValue)) {
+                        Text("Slots: \(roleValue.slotsTotal)")
+                    }
+
+                    if roleValue.slotsFilled > 0 {
+                        Text("Filled: \(roleValue.slotsFilled)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    TextField("Skills (comma separated)", text: roleBinding.skills)
+
+                    Toggle("Check-in required", isOn: roleBinding.checkInRequired)
+
+                    Toggle("Minimum age", isOn: roleBinding.minAgeEnabled)
+                    if roleValue.minAgeEnabled {
+                        Stepper(value: roleBinding.minAge, in: 1...100) {
+                            Text("Min age: \(roleValue.minAge)")
+                        }
+                    }
+
+                    if draft.roles.count > 1 {
+                        Button(roleRemovalLabel(for: roleValue)) {
+                            removeRole(id: roleValue.id)
+                        }
+                        .foregroundStyle(.red)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+
+            Button {
+                draft.roles.append(EventRoleDraft())
+            } label: {
+                Label("Add role", systemImage: "plus")
+            }
+        }
+    }
+
+    private var capacitySection: some View {
+        Section("RSVP cap") {
+            Toggle("Limit RSVPs", isOn: $draft.rsvpCapEnabled)
+            if draft.rsvpCapEnabled {
+                Stepper(value: $draft.rsvpCap, in: 1...1000) {
+                    Text("Cap: \(draft.rsvpCap)")
+                }
+            }
+        }
+    }
+
+    private var contactSection: some View {
+        Section("Contact") {
+            TextField("Contact name", text: $draft.contactName)
+            TextField("Contact email", text: $draft.contactEmail)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            TextField("Contact phone", text: $draft.contactPhone)
+                .keyboardType(.phonePad)
+        }
+    }
+
+    private var statusSection: some View {
+        Section("Visibility") {
+            Picker("Status", selection: $draft.status) {
+                ForEach(statusOptions, id: \.self) { status in
+                    Text(statusLabel(status)).tag(status)
+                }
+            }
+        }
+    }
+
+    private var submissionSection: some View {
+        Section {
+            if let message = submissionMessage {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+            Button {
+                Task { await submit() }
+            } label: {
+                if isSaving {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else {
+                    Text(primaryActionTitle)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+            .disabled(!canSubmit || isSaving)
+        }
+    }
+
+    private var availableOrganizations: [Organization] {
+        guard let user = store.user(for: userId) else { return [] }
+        let orgIds = Set(user.organizerProfile?.orgIds ?? [])
+        var organizations: [Organization]
+        if orgIds.isEmpty {
+            organizations = store.organizations.filter { $0.ownerUid == user.id }
+        } else {
+            organizations = store.organizations.filter { orgIds.contains($0.id) }
+        }
+        if let existingEvent,
+           let eventOrg = store.organizations.first(where: { $0.id == existingEvent.orgId }),
+           !organizations.contains(where: { $0.id == eventOrg.id }) {
+            organizations.append(eventOrg)
+        }
+        return organizations
+    }
+
+    private var canSubmit: Bool {
+        submissionMessage == nil && store.user(for: userId) != nil
+    }
+
+    private var submissionMessage: String? {
+        if availableOrganizations.isEmpty {
+            return "Add an organization in your profile to create events."
+        }
+        if selectedOrgId.isEmpty {
+            return "Select an organization."
+        }
+        return draft.validationMessage
+    }
+
+    private var primaryActionTitle: String {
+        if isEditing {
+            return "Save changes"
+        }
+        return draft.status == .published ? "Publish event" : "Save draft"
+    }
+
+    private var statusOptions: [EventStatus] {
+        [.draft, .published, .cancelled, .archived]
+    }
+
+    private func statusLabel(_ status: EventStatus) -> String {
+        switch status {
+        case .draft:
+            return "Draft"
+        case .published:
+            return "Published"
+        case .cancelled:
+            return "Cancelled"
+        case .archived:
+            return "Archived"
+        }
+    }
+
+    private func minSlots(for role: EventRoleDraft) -> Int {
+        max(1, role.slotsFilled)
+    }
+
+    private func maxSlots(for role: EventRoleDraft) -> Int {
+        max(200, role.slotsFilled)
+    }
+
+    private func removeRole(id: String) {
+        draft.roles.removeAll { $0.id == id }
+    }
+
+    private func roleRemovalLabel(for role: EventRoleDraft) -> String {
+        role.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Remove role" : "Remove \(role.title)"
+    }
+
+    private func prefill() {
+        guard let user = store.user(for: userId) else { return }
+        if selectedOrgId.isEmpty, let firstOrg = availableOrganizations.first {
+            selectedOrgId = firstOrg.id
+        }
+        if draft.contactName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            draft.contactName = user.displayName
+        }
+        if let email = user.contact?.email,
+           draft.contactEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            draft.contactEmail = email
+        }
+        if let phone = user.contact?.phone,
+           draft.contactPhone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            draft.contactPhone = phone
+        }
+    }
+
+    private func submit() async {
+        errorMessage = nil
+        guard let user = store.user(for: userId) else {
+            errorMessage = "User profile unavailable."
+            return
+        }
+        guard submissionMessage == nil else {
+            errorMessage = submissionMessage
+            return
+        }
+        isSaving = true
+        let (event, roles) = draft.buildEvent(
+            userId: user.id,
+            orgId: selectedOrgId,
+            eventId: existingEvent?.id,
+            createdAt: existingEvent?.createdAt,
+            createdBy: existingEvent?.createdBy
+        )
+        do {
+            try await store.saveEvent(event)
+            try await store.saveRoles(roles, for: event.id)
+            isSaving = false
+            dismiss()
+        } catch {
+            isSaving = false
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EventEditorView(userId: "user-jules")
+            .environmentObject(AppStore(dataSource: .mock, preload: true))
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Events/OrganizerEventListView.swift
+++ b/VolunQueer/VolunQueer/Views/Events/OrganizerEventListView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Organizer view for events they manage.
+struct OrganizerEventListView: View {
+    @EnvironmentObject private var store: AppStore
+
+    let userId: String
+
+    var body: some View {
+        Group {
+            if let user = store.user(for: userId) {
+                let managedEvents = store.events(managedBy: user).sorted { $0.startsAt < $1.startsAt }
+                let draftEvents = managedEvents.filter { $0.status == .draft }
+                let publishedEvents = managedEvents.filter { $0.status == .published }
+                let archivedEvents = managedEvents.filter { $0.status == .cancelled || $0.status == .archived }
+                if managedEvents.isEmpty {
+                    ContentUnavailableView(
+                        "No events yet",
+                        systemImage: "calendar.badge.plus",
+                        description: Text("Create your first volunteer opportunity.")
+                    )
+                } else {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 16) {
+                            if !draftEvents.isEmpty {
+                                sectionHeader("Drafts")
+                                eventRows(draftEvents)
+                            }
+                            if !publishedEvents.isEmpty {
+                                sectionHeader("Published")
+                                eventRows(publishedEvents)
+                            }
+                            if !archivedEvents.isEmpty {
+                                sectionHeader("Archived")
+                                eventRows(archivedEvents)
+                            }
+                        }
+                        .padding()
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "Organizer profile missing",
+                    systemImage: "person.crop.circle.badge.exclam",
+                    description: Text("Complete onboarding to create events.")
+                )
+            }
+        }
+        .background(Theme.cream)
+        .navigationDestination(for: Event.self) { event in
+            EventDetailView(event: event)
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline)
+            .foregroundStyle(Theme.softCharcoal)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func eventRows(_ events: [Event]) -> some View {
+        ForEach(events) { event in
+            NavigationLink(value: event) {
+                OrganizerEventRowView(event: event, store: store)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OrganizerEventListView(userId: "user-jules")
+            .environmentObject(AppStore(dataSource: .mock, preload: true))
+    }
+}

--- a/VolunQueer/VolunQueer/Views/Events/OrganizerEventRowView.swift
+++ b/VolunQueer/VolunQueer/Views/Events/OrganizerEventRowView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Organizer card row with event status and quick details.
+struct OrganizerEventRowView: View {
+    let event: Event
+    let store: AppStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ZStack(alignment: .topTrailing) {
+                EventCardView(event: event, store: store, rsvpStatus: nil)
+                Text(statusLabel)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .foregroundStyle(statusForeground)
+                    .background(statusForeground.opacity(0.15))
+                    .clipShape(Capsule())
+                    .padding(10)
+            }
+            coverageSummary
+        }
+    }
+
+    private var statusLabel: String {
+        switch event.status {
+        case .draft:
+            return "Draft"
+        case .published:
+            return "Published"
+        case .cancelled:
+            return "Cancelled"
+        case .archived:
+            return "Archived"
+        }
+    }
+
+    private var statusForeground: Color {
+        switch event.status {
+        case .draft:
+            return .secondary
+        case .published:
+            return Theme.skyTeal
+        case .cancelled:
+            return .orange
+        case .archived:
+            return .secondary
+        }
+    }
+
+    private var coverageSummary: some View {
+        let roles = store.roles(for: event)
+        let totals = roles.reduce(into: (total: 0, filled: 0)) { result, role in
+            result.total += role.slotsTotal
+            result.filled += role.slotsFilled
+        }
+        let openSlots = max(totals.total - totals.filled, 0)
+
+        return HStack(spacing: 12) {
+            if totals.total > 0 {
+                Text("Filled \(totals.filled)/\(totals.total)")
+                Text("Open \(openSlots)")
+            } else {
+                Text("No roles yet")
+            }
+
+            if let cap = event.rsvpCap {
+                Text("Cap \(cap)")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+}
+
+#Preview {
+    let store = AppStore(dataSource: .mock, preload: true)
+    OrganizerEventRowView(event: MockData.bundle.events[0], store: store)
+}

--- a/VolunQueer/VolunQueer/Views/Tabs/OrganizerTabView.swift
+++ b/VolunQueer/VolunQueer/Views/Tabs/OrganizerTabView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Tab wrapper for organizer management (event list + creation).
+struct OrganizerTabView: View {
+    @EnvironmentObject private var store: AppStore
+    @EnvironmentObject private var authStore: AuthStore
+
+    let userId: String
+
+    @State private var isPresentingEditor = false
+
+    var body: some View {
+        NavigationStack {
+            OrganizerEventListView(userId: userId)
+                .navigationTitle("Manage")
+                .toolbar {
+                    ToolbarItemGroup(placement: .topBarTrailing) {
+                        Button {
+                            isPresentingEditor = true
+                        } label: {
+                            Label("New Event", systemImage: "plus")
+                        }
+
+                        Button("Reload") {
+                            Task { await store.load() }
+                        }
+                    }
+
+                    if store.dataSource == .firestore {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button("Seed Firestore") {
+                                Task { await store.seedMockData() }
+                            }
+                        }
+                    }
+
+                    ToolbarItem(placement: .bottomBar) {
+                        Button("Sign Out") {
+                            authStore.signOut()
+                        }
+                    }
+                }
+        }
+        .sheet(isPresented: $isPresentingEditor) {
+            NavigationStack {
+                EventEditorView(userId: userId)
+            }
+        }
+    }
+}
+
+#Preview {
+    OrganizerTabView(userId: "user-jules")
+        .environmentObject(AppStore(dataSource: .mock, preload: true))
+        .environmentObject(AuthStore(isConfigured: false))
+}

--- a/VolunQueer/VolunQueerTests/EventDraftTests.swift
+++ b/VolunQueer/VolunQueerTests/EventDraftTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import VolunQueer
+
+struct EventDraftTests {
+    @Test
+    func validatesRequiredFields() {
+        var draft = EventDraft(now: Date(timeIntervalSince1970: 0))
+        draft.title = "Community Dinner"
+        draft.locationName = "Center"
+        draft.roles = [EventRoleDraft()]
+        draft.roles[0].title = "Host"
+        draft.roles[0].slotsTotal = 4
+        draft.startsAt = Date(timeIntervalSince1970: 0)
+        draft.endsAt = Date(timeIntervalSince1970: 3600)
+
+        #expect(draft.validationMessage == nil)
+    }
+
+    @Test
+    func buildsEventWithTagsAndContact() {
+        var draft = EventDraft(now: Date(timeIntervalSince1970: 0))
+        draft.title = "Community Dinner"
+        draft.description = "Serve food and welcome guests."
+        draft.locationName = "Center"
+        draft.tags = "Community, Food"
+        draft.accessibilityNotes = "Wheelchair accessible"
+        draft.accessibilityTags = "ASL, Masks"
+        draft.contactName = "Alex"
+        draft.contactEmail = "alex@example.com"
+        draft.roles = [EventRoleDraft()]
+        draft.roles[0].title = "Host"
+        draft.roles[0].slotsTotal = 3
+        draft.rsvpCapEnabled = true
+        draft.rsvpCap = 10
+        draft.startsAt = Date(timeIntervalSince1970: 0)
+        draft.endsAt = Date(timeIntervalSince1970: 3600)
+
+        let createdAt = Date(timeIntervalSince1970: 0)
+        let (event, roles) = draft.buildEvent(userId: "user-1", orgId: "org-1", createdAt: createdAt)
+
+        #expect(event.orgId == "org-1")
+        #expect(event.tags == ["Community", "Food"])
+        #expect(event.accessibility?.notes == "Wheelchair accessible")
+        #expect(event.accessibility?.tags == ["ASL", "Masks"])
+        #expect(event.contact?.email == "alex@example.com")
+        #expect(event.rsvpCap == 10)
+        #expect(roles.count == 1)
+        #expect(roles[0].title == "Host")
+    }
+}


### PR DESCRIPTION
• PR title:
  Add organizer event editing, multi‑role management, and coverage analytics

  PR description:
  Summary

  - Added organizer event editing with status controls (draft/publish/cancel/archive).
  - Enabled multi‑role creation/editing with per‑role details (slots, skills, min age, check‑in).
  - Added organizer coverage summary (filled/open/cap) on Manage list.
  - Added Firestore role deletion when roles are removed.
  - Added EventDraft + tests for validation/building.

  Notes

  - No changes to local Xcode files or GoogleService-Info.plist are included in this branch.